### PR TITLE
added option for line chart bg fill opacity

### DIFF
--- a/chart_option.go
+++ b/chart_option.go
@@ -71,6 +71,8 @@ type ChartOption struct {
 	BarHeight int
 	// Fill the area of line chart
 	FillArea bool
+	// background fill (alpha) opacity
+	Opacity uint8
 	// The child charts
 	Children []ChartOption
 	// The value formatter

--- a/charts.go
+++ b/charts.go
@@ -409,6 +409,7 @@ func Render(opt ChartOption, opts ...OptionFunc) (*Painter, error) {
 				SymbolShow:  opt.SymbolShow,
 				StrokeWidth: opt.LineStrokeWidth,
 				FillArea:    opt.FillArea,
+				Opacity:     opt.Opacity,
 			}).render(renderResult, lineSeriesList)
 			return err
 		})

--- a/line_chart.go
+++ b/line_chart.go
@@ -70,6 +70,8 @@ type LineChartOption struct {
 	FillArea bool
 	// background is filled
 	backgroundIsFilled bool
+	// background fill (alpha) opacity
+	Opacity uint8
 }
 
 func (l *lineChart) render(result *defaultRenderResult, seriesList SeriesList) (Box, error) {
@@ -156,6 +158,10 @@ func (l *lineChart) render(result *defaultRenderResult, seriesList SeriesList) (
 			areaPoints := make([]Point, len(points))
 			copy(areaPoints, points)
 			bottomY := yRange.getRestHeight(yRange.min)
+			var opacity uint8 = 200
+			if opt.Opacity != 0 {
+				opacity = opt.Opacity
+			}
 			areaPoints = append(areaPoints, Point{
 				X: areaPoints[len(areaPoints)-1].X,
 				Y: bottomY,
@@ -164,7 +170,7 @@ func (l *lineChart) render(result *defaultRenderResult, seriesList SeriesList) (
 				Y: bottomY,
 			}, areaPoints[0])
 			seriesPainter.SetDrawingStyle(Style{
-				FillColor: seriesColor.WithAlpha(200),
+				FillColor: seriesColor.WithAlpha(opacity),
 			})
 			seriesPainter.FillArea(areaPoints)
 		}


### PR DESCRIPTION
I'm using cron-generated charts for display on my desktop with conky, so I added an option to set the transparency of fill area of line charts.